### PR TITLE
Speed up App Start and Tests by only Transpiling Typescript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN echo '#!/bin/bash\nnpx typeorm-model-generator --noConfig -h $DB_HOST -d $DB
 RUN chmod +x /sbin/typeorm-model-generator.sh
 
 COPY . /app
+ENV TS_NODE_TRANSPILE_ONLY=1
 
 RUN npm run-script build
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/bodgery/bodgery-member-api",
   "license": "BSD-2-Clause",
   "scripts": {
-    "start": "ts-node app.ts start",
+    "start": "ts-node --transpile-only app.ts start",
     "build": "tsc",
     "test": "mocha --require ts-node/register --watch-extensions ts,tsx --timeout 5000 \"test/**/*.{ts,tsx}\""
   },


### PR DESCRIPTION
Skip the type-checking and other optimizations when running app-start
and mocha under ts-node