### PR TITLE
Migrate from Globals to App Singletons

### DIFF
--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,5 +1,6 @@
 require:
   - ts-node/register
+  - ./test/connection-hooks.ts
 
 extension:
   - ts

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,4 @@
 import {NextFunction, Request, RequestHandler, Response} from "express";
-import {getCustomRepository} from "typeorm";
 import {UserRepository} from "./typeorm/user_repository";
 import {access_token as AccessToken} from "./typeorm/entities/access_token";
 import {users as User} from "./typeorm/entities/users";
@@ -22,7 +21,7 @@ export async function BearerTokenProvider( req: Request ): Promise<User | null>
         return null;
     }
 
-    const repo = getCustomRepository(UserRepository);
+    const repo = req.app.orm.getCustomRepository(UserRepository);
     return await repo.findByAccessToken(token);
 }
 
@@ -30,13 +29,11 @@ export async function SessionProvider( req: Request ): Promise<User | null>
 {
     const email = req.session.username;
 
-    console.log(`Loading session email: ${email}`);
-
     if (!email) {
         return null;
     }
 
-    const repo = getCustomRepository(UserRepository);
+    const repo = req.app.orm.getCustomRepository(UserRepository);
     return await repo.findByEmail(email);
 }
 

--- a/src/typeorm_db.ts
+++ b/src/typeorm_db.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import { Config } from "./config";
 
-import {createConnection as typeormCreateConnection, Connection } from "typeorm";
+import {createConnection as typeormCreateConnection, Connection as _Connection } from "typeorm";
 
 function typeorm_args( conf: Config )
 {
@@ -29,6 +29,8 @@ function typeorm_args( conf: Config )
         }
     };
 }
+
+export type Connection = _Connection;
 
 export default async function createConnection( conf: Config ): Promise<Connection> {
     return await typeormCreateConnection( typeorm_args( conf ) );

--- a/test/add-member.ts
+++ b/test/add-member.ts
@@ -6,14 +6,16 @@ import * as mock_db from "../src/db-mock";
 
 
 describe( 'PUT /v1/member', function () {
-    before( () => {
+    let app;
+
+    before( async () => {
         process.env['TEST_RUN'] = "1";
         let db = new mock_db.MockDB([], {});
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Adds a member', function (done) {
-        request( server.SERVER )
+        request( app )
             .put( '/api/v1/member' )
             .send({
                 rfid: "00000000"
@@ -35,6 +37,5 @@ describe( 'PUT /v1/member', function () {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/add-member.ts
+++ b/test/add-member.ts
@@ -8,7 +8,7 @@ import * as mock_db from "../src/db-mock";
 describe( 'PUT /v1/member', function () {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
         let db = new mock_db.MockDB([], {});
         app = await server.createApp(this.connection, db );
@@ -35,7 +35,7 @@ describe( 'PUT /v1/member', function () {
             });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/connection-hooks.ts
+++ b/test/connection-hooks.ts
@@ -1,0 +1,22 @@
+import config from "../src/config";
+import createConnection, {Connection} from "../src/typeorm_db";
+
+// Need to merge the `connection` propetty we're adding to the Mocha Suite prototype
+declare module 'mocha' {
+    interface Suite {
+        connection: Connection;
+    }
+}
+
+export const mochaHooks = {
+
+    async beforeAll() {
+        const conf = config();
+        this.connection = await createConnection( conf );
+    },
+
+    async afterAll() {
+        await this.connection.close();
+    },
+
+}

--- a/test/csrf.ts
+++ b/test/csrf.ts
@@ -9,7 +9,7 @@ describe(
     function () {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         let db = new mock_db.MockDB([], {});
         app = await server.createApp(this.connection, db );
     });

--- a/test/csrf.ts
+++ b/test/csrf.ts
@@ -7,14 +7,16 @@ import * as mock_db from "../src/db-mock";
 describe(
     'Checks that CSRF tokens are required on methods that change state',
     function () {
-    before( () => {
+    let app;
+
+    before( async () => {
         let db = new mock_db.MockDB([], {});
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
 /*
     it( 'Adds a member', function (done) {
-        request( server.SERVER )
+        request( app )
             .put( '/api/v1/member' )
             .send({
                 rfid: "00000000"
@@ -31,8 +33,4 @@ describe(
             });
     });
  */
-
-    after( () => {
-        return server.stop();
-    });
 });

--- a/test/email-group-new-member.ts
+++ b/test/email-group-new-member.ts
@@ -9,8 +9,9 @@ const TEST_PHOTO = "test_data/bodgery_logo.jpg";
 
 
 describe( 'POST /v1/member/:member_id/send_group_signup_email', function () {
+    let app;
     let test_email;
-    before( () => {
+    before( async () => {
         test_email = process.env['TEST_EMAIL'];
         let members = {
             "01": {
@@ -56,12 +57,12 @@ describe( 'POST /v1/member/:member_id/send_group_signup_email', function () {
             }
         });
 
-        return server.start( db, conf, wa_mock );
+        app = await server.createApp(this.connection, db, conf, wa_mock );
     });
 
     it( 'Sends the new member signup email for the group', function (done) {
         if( test_email ) {
-            request( server.SERVER )
+            request( app )
                 .post( '/api/v1/member/01/send_group_signup_email' )
                 .expect( 200 )
                 .end( function( err, res ) {
@@ -74,9 +75,5 @@ describe( 'POST /v1/member/:member_id/send_group_signup_email', function () {
                 + " to run this test" );
             done();
         }
-    });
-
-    after( () => {
-        return server.stop();
     });
 });

--- a/test/email-group-new-member.ts
+++ b/test/email-group-new-member.ts
@@ -11,7 +11,7 @@ const TEST_PHOTO = "test_data/bodgery_logo.jpg";
 describe( 'POST /v1/member/:member_id/send_group_signup_email', function () {
     let app;
     let test_email;
-    before( async () => {
+    beforeEach( async function() {
         test_email = process.env['TEST_EMAIL'];
         let members = {
             "01": {

--- a/test/email-new-member.ts
+++ b/test/email-new-member.ts
@@ -7,7 +7,7 @@ import * as mock_db from "../src/db-mock";
 describe( 'POST /v1/member/:member_id/send_signup_email', function () {
     let app;
     let test_email;
-    before( async () => {
+    beforeEach( async function() {
         test_email = process.env['TEST_EMAIL'];
         let members = {
             "01": {

--- a/test/email-new-member.ts
+++ b/test/email-new-member.ts
@@ -5,8 +5,9 @@ import * as mock_db from "../src/db-mock";
 
 
 describe( 'POST /v1/member/:member_id/send_signup_email', function () {
+    let app;
     let test_email;
-    before( () => {
+    before( async () => {
         test_email = process.env['TEST_EMAIL'];
         let members = {
             "01": {
@@ -21,12 +22,12 @@ describe( 'POST /v1/member/:member_id/send_signup_email', function () {
             }
         };
         let db = new mock_db.MockDB( members, {} );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Sends the new member signup email', function (done) {
         if( test_email ) {
-            request( server.SERVER )
+            request( app )
                 .post( '/api/v1/member/01/send_signup_email' )
                 .expect( 200 )
                 .end( function( err, res ) {
@@ -39,9 +40,5 @@ describe( 'POST /v1/member/:member_id/send_signup_email', function () {
                 + " to run this test" );
             done();
         }
-    });
-
-    after( () => {
-        return server.stop();
     });
 });

--- a/test/get-member-address.ts
+++ b/test/get-member-address.ts
@@ -10,7 +10,7 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 describe( 'GET /v1/member/:member_id/address', function () {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
 
         let members = {};
@@ -51,7 +51,7 @@ describe( 'GET /v1/member/:member_id/address', function () {
             });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/get-member-address.ts
+++ b/test/get-member-address.ts
@@ -8,7 +8,9 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 
 
 describe( 'GET /v1/member/:member_id/address', function () {
-    before( () => {
+    let app;
+
+    before( async () => {
         process.env['TEST_RUN'] = "1";
 
         let members = {};
@@ -30,11 +32,11 @@ describe( 'GET /v1/member/:member_id/address', function () {
             }
         };
         let db = new mock_db.MockDB( members, {} );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Gets a member address', function (done) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/member/' + uuid + '/address' )
             .send()
             .expect( 200 )
@@ -51,6 +53,5 @@ describe( 'GET /v1/member/:member_id/address', function () {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/get-member.ts
+++ b/test/get-member.ts
@@ -10,7 +10,7 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 describe( 'GET /v1/member', function () {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
 
         let members = {}
@@ -46,7 +46,7 @@ describe( 'GET /v1/member', function () {
             });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/get-member.ts
+++ b/test/get-member.ts
@@ -8,7 +8,9 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 
 
 describe( 'GET /v1/member', function () {
-    before( () => {
+    let app;
+
+    before( async () => {
         process.env['TEST_RUN'] = "1";
 
         let members = {}
@@ -23,11 +25,11 @@ describe( 'GET /v1/member', function () {
             }
         };
         let db = new mock_db.MockDB( members, {} );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Fetches a member', function (done) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/member/' + uuid )
             .send()
             .expect( 200 )
@@ -46,6 +48,5 @@ describe( 'GET /v1/member', function () {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/get-members.ts
+++ b/test/get-members.ts
@@ -81,7 +81,7 @@ describe( 'GET /v1/members', function () {
     });
 
     it( 'Fetches all members', function (done) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/members' )
             .send()
             .expect( 200 )
@@ -100,7 +100,7 @@ describe( 'GET /v1/members', function () {
     });
 
     it( 'Fetch a specific member by ID', function ( done ) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/members' )
             .send({ id: "1235" })
             .expect( 200 )
@@ -121,7 +121,7 @@ describe( 'GET /v1/members', function () {
     });
 
     it( 'Fetch members with limit', function ( done ) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/members' )
             .send({ limit: 3 })
             .expect( 200 )
@@ -139,7 +139,7 @@ describe( 'GET /v1/members', function () {
     });
 
     it( 'Fetch members with limit and skip', function ( done ) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/members' )
             .send({
                 limit: 3
@@ -160,7 +160,7 @@ describe( 'GET /v1/members', function () {
     });
 
     it( 'Fetch members with sorting', function ( done ) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/members' )
             .send({
                 sort: "name"
@@ -177,10 +177,6 @@ describe( 'GET /v1/members', function () {
                 if( err ) return done(err);
                 done();
             });
-    });
-
-    after( () => {
-        server.stop();
     });
 });
 */

--- a/test/get-pending-members-real.ts
+++ b/test/get-pending-members-real.ts
@@ -7,14 +7,16 @@ import * as wa_api from "../src/wild_apricot_mock";
 
 
 describe( 'GET /v1/members/pending', function() {
-    before( () => {
+    let app;
+
+    before( async () => {
         process.env['TEST_RUN'] = "1"
         let db = new mock_db.MockDB( null, null );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Gets all pending members on actual Wild Apricot', function(done) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/members/pending' )
             .send()
             .expect( 200 )
@@ -32,6 +34,5 @@ describe( 'GET /v1/members/pending', function() {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/get-pending-members-real.ts
+++ b/test/get-pending-members-real.ts
@@ -9,7 +9,7 @@ import * as wa_api from "../src/wild_apricot_mock";
 describe( 'GET /v1/members/pending', function() {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1"
         let db = new mock_db.MockDB( null, null );
         app = await server.createApp(this.connection, db );
@@ -32,7 +32,7 @@ describe( 'GET /v1/members/pending', function() {
             })
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/get-pending-members.ts
+++ b/test/get-pending-members.ts
@@ -9,7 +9,7 @@ import * as wa_api from "../src/wild_apricot_mock";
 describe( 'GET /v1/members/pending', function() {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
         let wa_mock = new wa_api.MockWA({
             // TODO fill in pending and existing members
@@ -83,7 +83,7 @@ describe( 'GET /v1/members/pending', function() {
             })
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/get-pending-members.ts
+++ b/test/get-pending-members.ts
@@ -7,7 +7,9 @@ import * as wa_api from "../src/wild_apricot_mock";
 
 
 describe( 'GET /v1/members/pending', function() {
-    before( () => {
+    let app;
+
+    before( async () => {
         process.env['TEST_RUN'] = "1";
         let wa_mock = new wa_api.MockWA({
             // TODO fill in pending and existing members
@@ -57,11 +59,11 @@ describe( 'GET /v1/members/pending', function() {
             ]
         });
         let db = new mock_db.MockDB( null, null );
-        return server.start( db, null, wa_mock );
+        app = await server.createApp(this.connection, db, null, wa_mock );
     });
 
     it( 'Gets all pending members', function(done) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/members/pending' )
             .send()
             .expect( 200 )
@@ -83,6 +85,5 @@ describe( 'GET /v1/members/pending', function() {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/google-group-signup.ts
+++ b/test/google-group-signup.ts
@@ -8,7 +8,7 @@ describe( 'PUT /v1/member/:member_id/google_group_signup', function () {
     let app;
 
     let test_email;
-    before( async () => {
+    beforeEach( async function() {
         test_email = process.env['TEST_EMAIL'];
         let members = {
             "01": {

--- a/test/google-group-signup.ts
+++ b/test/google-group-signup.ts
@@ -5,8 +5,10 @@ import * as mock_db from "../src/db-mock";
 
 
 describe( 'PUT /v1/member/:member_id/google_group_signup', function () {
+    let app;
+
     let test_email;
-    before( () => {
+    before( async () => {
         test_email = process.env['TEST_EMAIL'];
         let members = {
             "01": {
@@ -21,12 +23,12 @@ describe( 'PUT /v1/member/:member_id/google_group_signup', function () {
             }
         };
         let db = new mock_db.MockDB( members, {} );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Adds member to the Google Group list', function (done) {
         if( test_email ) {
-            request( server.SERVER )
+            request( app )
                 .put( '/api/v1/member/01/google_group_signup' )
                 .expect( 200 )
                 .end( function( err, res ) {
@@ -39,9 +41,5 @@ describe( 'PUT /v1/member/:member_id/google_group_signup', function () {
                 + " to run this test" );
             done();
         }
-    });
-
-    after( () => {
-        return server.stop();
     });
 });

--- a/test/google-oauth-callback.ts
+++ b/test/google-oauth-callback.ts
@@ -5,11 +5,13 @@ import * as server from "../app";
 
 
 describe( 'GET /v1/google_oauth', function () {
+    let app;
+
     let token_file = 'tmp-google-token';
-    before( () => {
+    before( async () => {
         let conf = server.default_conf();
         conf['google_oauth_token_path'] = token_file;
-        return server.start( null, conf );
+        app = await server.createApp(this.connection, null, conf );
     });
 
     // Disabiling this test, as the key is being fetched by another method
@@ -17,7 +19,7 @@ describe( 'GET /v1/google_oauth', function () {
     it( 'Sets a token for the google oauth callback', function (done) {
         let token_code = "xyz123";
 
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/google_oauth?code=' + token_code )
             .send()
             .expect( 200 )
@@ -41,17 +43,11 @@ describe( 'GET /v1/google_oauth', function () {
     */
 
     after( () => {
-        let stop_promise = server.stop();
-        let unlink_promise = new Promise( (resolve, reject) => {
+        return new Promise( (resolve, reject) => {
             fs.unlink( token_file, (err) => {
                 // Ignore any error, we're just finished
                 resolve();
             });
         });
-
-        return Promise.all([
-            stop_promise
-            ,unlink_promise
-        ]);
     });
 });

--- a/test/google-oauth-callback.ts
+++ b/test/google-oauth-callback.ts
@@ -8,7 +8,7 @@ describe( 'GET /v1/google_oauth', function () {
     let app;
 
     let token_file = 'tmp-google-token';
-    before( async () => {
+    beforeEach( async function() {
         let conf = server.default_conf();
         conf['google_oauth_token_path'] = token_file;
         app = await server.createApp(this.connection, null, conf );
@@ -42,7 +42,7 @@ describe( 'GET /v1/google_oauth', function () {
     });
     */
 
-    after( () => {
+    afterEach( async function() {
         return new Promise( (resolve, reject) => {
             fs.unlink( token_file, (err) => {
                 // Ignore any error, we're just finished

--- a/test/member-is-active.ts
+++ b/test/member-is-active.ts
@@ -9,9 +9,11 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 
 
 describe( '/v1/member/:member_id/is_active', function () {
+    let app;
+
     let wa_mock: wa_api.MockWA;
 
-    before( () => {
+    before( async () => {
         process.env['TEST_RUN'] = "1";
         let members = {};
         members[uuid] =  {
@@ -28,14 +30,14 @@ describe( '/v1/member/:member_id/is_active', function () {
             members: wa_members
         });
 
-        return server.start( db, null, wa_mock );
+        app = await server.createApp(this.connection, db, null, wa_mock );
     });
 
     it( 'Sets member status', function (done) {
         let fetch_status = (
             callback: ( res ) => void
         ) => {
-            request( server.SERVER )
+            request( app )
                 .get( '/api/v1/member/' + uuid + '/is_active' )
                 .send()
                 .expect( 200 )
@@ -63,7 +65,7 @@ describe( '/v1/member/:member_id/is_active', function () {
             status: boolean
             ,callback: ( res ) => void
         ) => {
-            request( server.SERVER )
+            request( app )
                 .put( '/api/v1/member/' + uuid + '/is_active' )
                 .send({ is_active: status })
                 .expect( 200 )
@@ -89,6 +91,5 @@ describe( '/v1/member/:member_id/is_active', function () {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/member-is-active.ts
+++ b/test/member-is-active.ts
@@ -13,7 +13,7 @@ describe( '/v1/member/:member_id/is_active', function () {
 
     let wa_mock: wa_api.MockWA;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
         let members = {};
         members[uuid] =  {
@@ -89,7 +89,7 @@ describe( '/v1/member/:member_id/is_active', function () {
         });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/member-log-rfid.ts
+++ b/test/member-log-rfid.ts
@@ -9,7 +9,7 @@ describe( 'Log RFID', function () {
     let app;
     let db;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
 
         db = new mock_db.MockDB( {}, {} );
@@ -33,7 +33,7 @@ describe( 'Log RFID', function () {
             });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/member-log-rfid.ts
+++ b/test/member-log-rfid.ts
@@ -6,17 +6,18 @@ import * as mock_db from "../src/db-mock";
 
 
 describe( 'Log RFID', function () {
+    let app;
     let db;
 
-    before( () => {
+    before( async () => {
         process.env['TEST_RUN'] = "1";
 
         db = new mock_db.MockDB( {}, {} );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Logs a successful RFID entry', function (done) {
-        request( server.SERVER )
+        request( app )
             .post( '/api/v1/rfid/log_entry/000123/true' )
             .send()
             .expect( 200 )
@@ -34,6 +35,5 @@ describe( 'Log RFID', function () {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/member-rfid.ts
+++ b/test/member-rfid.ts
@@ -16,7 +16,7 @@ describe( 'RFID management', function () {
     let inactive_rfid = "1234567000";
 
 
-    before( async () => {
+    beforeEach( async function() {
         let members = {};
         members[uuid1] = {
             is_active: true

--- a/test/member-rfid.ts
+++ b/test/member-rfid.ts
@@ -9,12 +9,14 @@ const uuid2 = "c28ec74e-2459-488e-9aec-f6068e8a08a7";
 
 
 describe( 'RFID management', function () {
+    let app;
+
     let good_rfid = "0001234567";
     let invalid_rfid = "0007654321";
     let inactive_rfid = "1234567000";
 
 
-    before( () => {
+    before( async () => {
         let members = {};
         members[uuid1] = {
             is_active: true
@@ -25,12 +27,12 @@ describe( 'RFID management', function () {
             ,rfid: inactive_rfid
         };
         let db = new mock_db.MockDB( members, {} );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Sets an RFID on a valid member', function (done) {
         let fetch_status = () => {
-            request( server.SERVER )
+            request( app )
                 .get( '/api/v1/rfid/' + good_rfid )
                 .send()
                 .expect( 200 )
@@ -41,7 +43,7 @@ describe( 'RFID management', function () {
         };
 
         process.env['TEST_RUN'] = "1";
-        request( server.SERVER )
+        request( app )
             .put( '/api/v1/member/' + uuid1 + '/rfid' )
             .send({ rfid: good_rfid })
             .expect( 200 )
@@ -53,7 +55,7 @@ describe( 'RFID management', function () {
     });
 
     it( 'Tries to fetch a member that doesn\'t exist', function (done) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/rfid/' + invalid_rfid )
             .send()
             .expect( 404 )
@@ -64,7 +66,7 @@ describe( 'RFID management', function () {
     });
 
     it( 'Tries to fetch an inactive member', function (done) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/rfid/' + inactive_rfid )
             .send()
             .expect( 403 )
@@ -72,9 +74,5 @@ describe( 'RFID management', function () {
                 if( err ) done(err);
                 else done();
             });
-    });
-
-    after( () => {
-        return server.stop();
     });
 });

--- a/test/not-found-error.ts
+++ b/test/not-found-error.ts
@@ -5,7 +5,7 @@ import * as server from "../app";
 describe( "Not found error", function () {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
         app = await server.createApp(this.connection, );
     });
@@ -21,7 +21,7 @@ describe( "Not found error", function () {
             });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/not-found-error.ts
+++ b/test/not-found-error.ts
@@ -3,12 +3,15 @@ import * as server from "../app";
 
 
 describe( "Not found error", function () {
-    before( () => {
+    let app;
+
+    before( async () => {
         process.env['TEST_RUN'] = "1";
+        app = await server.createApp(this.connection, );
     });
 
     it( "Checks for not found error", function (done) {
-        request( server.SERVER )
+        request( app )
             .get( '/not/found' )
             .expect( 404 )
             .expect( 'content-type', /html/ )

--- a/test/rfid-dump.ts
+++ b/test/rfid-dump.ts
@@ -8,7 +8,9 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 
 
 describe( 'GET /v1/rfids', function () {
-    before( () => {
+    let app;
+
+    before( async () => {
         process.env['TEST_RUN'] = "1";
 
         let members = {}
@@ -34,11 +36,11 @@ describe( 'GET /v1/rfids', function () {
         };
 
         let db = new mock_db.MockDB( members, {} );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Fetches the RFID dump', function (done) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/v1/rfids' )
             .send()
             .expect( 200 )
@@ -55,6 +57,5 @@ describe( 'GET /v1/rfids', function () {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/rfid-dump.ts
+++ b/test/rfid-dump.ts
@@ -10,7 +10,7 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 describe( 'GET /v1/rfids', function () {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
 
         let members = {}
@@ -55,7 +55,7 @@ describe( 'GET /v1/rfids', function () {
             });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/set-member-address.ts
+++ b/test/set-member-address.ts
@@ -9,7 +9,7 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 describe( 'PUT /v1/member/:member_id/address', function () {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
         let members = {};
         members[uuid] = {
@@ -43,7 +43,7 @@ describe( 'PUT /v1/member/:member_id/address', function () {
             });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/set-member-address.ts
+++ b/test/set-member-address.ts
@@ -7,7 +7,9 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 
 
 describe( 'PUT /v1/member/:member_id/address', function () {
-    before( () => {
+    let app;
+
+    before( async () => {
         process.env['TEST_RUN'] = "1";
         let members = {};
         members[uuid] = {
@@ -21,11 +23,11 @@ describe( 'PUT /v1/member/:member_id/address', function () {
             }
         };
         let db = new mock_db.MockDB( members, {} );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Sets a member address', function (done) {
-        request( server.SERVER )
+        request( app )
             .put( '/api/v1/member/' + uuid + '/address' )
             .send({
                 name: "Foo Bar"
@@ -43,6 +45,5 @@ describe( 'PUT /v1/member/:member_id/address', function () {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/set-member-photos.ts
+++ b/test/set-member-photos.ts
@@ -13,7 +13,7 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 describe( 'PUT /v1/member/:member_id/photo', function () {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
         let members = {};
         members[uuid] = {
@@ -70,7 +70,7 @@ describe( 'PUT /v1/member/:member_id/photo', function () {
         });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
 
         // Just delete everything in the test photo dir

--- a/test/set-member-wild-apricot.ts
+++ b/test/set-member-wild-apricot.ts
@@ -11,7 +11,7 @@ describe( 'PUT /v1/member/:member_id/wildapricot', function () {
     let app;
     let members;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
         members = {};
         members[uuid] = {
@@ -41,7 +41,7 @@ describe( 'PUT /v1/member/:member_id/wildapricot', function () {
             });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/set-member-wild-apricot.ts
+++ b/test/set-member-wild-apricot.ts
@@ -8,8 +8,10 @@ const uuid = "0662df8c-e43a-4e90-8b03-3849afbb533e";
 
 
 describe( 'PUT /v1/member/:member_id/wildapricot', function () {
+    let app;
     let members;
-    before( () => {
+
+    before( async () => {
         process.env['TEST_RUN'] = "1";
         members = {};
         members[uuid] = {
@@ -18,11 +20,11 @@ describe( 'PUT /v1/member/:member_id/wildapricot', function () {
             }
         };
         let db = new mock_db.MockDB( members, {} );
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
     it( 'Sets a member wild apricot ID', function (done) {
-        request( server.SERVER )
+        request( app )
             .put( '/api/v1/member/' + uuid + '/wildapricot' )
             .send({
                 wild_apricot_id: "567"
@@ -41,6 +43,5 @@ describe( 'PUT /v1/member/:member_id/wildapricot', function () {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });

--- a/test/user-authorization-oauth2.ts
+++ b/test/user-authorization-oauth2.ts
@@ -6,21 +6,22 @@ import * as passwd from "../src/password";
 
 
 describe( "User authorization with OAuth2", function () {
+    let app;
     let db: mock_db.MockDB;
     let token = "foobarbaz";
 
 
-    before( () => {
+    before( async () => {
         let tokens = {};
         tokens[token] = true;
         db = new mock_db.MockDB( {}, {}, null, tokens );
 
-        return server.start( db );
+        app = await server.createApp(this.connection, db );
     });
 
 
     it( 'Sends an OAuth2 token to a secure page', (done) => {
-        request( server.SERVER )
+        request( app )
             .get( '/members/pending' )
             .set( 'Authorization', 'Bearer ' + token )
             .expect( 200 )
@@ -28,9 +29,5 @@ describe( "User authorization with OAuth2", function () {
                 if(err) done(err);
                 else done();
             });
-    });
-
-    after( () => {
-        return server.stop();
     });
 });

--- a/test/user-authorization-oauth2.ts
+++ b/test/user-authorization-oauth2.ts
@@ -11,7 +11,7 @@ describe( "User authorization with OAuth2", function () {
     let token = "foobarbaz";
 
 
-    before( async () => {
+    beforeEach( async function() {
         let tokens = {};
         tokens[token] = true;
         db = new mock_db.MockDB( {}, {}, null, tokens );

--- a/test/user-authorization.ts
+++ b/test/user-authorization.ts
@@ -19,7 +19,7 @@ describe( "User authorization", function () {
     let trust_header_name = 'X-Forwarded-Proto';
     let trust_header_value = 'https';
 
-    before( async () => {
+    beforeEach( async function() {
         let conf = server.default_conf();
         conf['preferred_password_crypt_method'] = checker_str;
 
@@ -128,5 +128,5 @@ describe( "User authorization", function () {
             });
     });
 
-    after(() => sinon.restore());
+    afterEach(() => sinon.restore());
 });

--- a/test/user-login.ts
+++ b/test/user-login.ts
@@ -22,7 +22,7 @@ describe( "User login", function () {
     let trust_header_name = 'X-Forwarded-Proto';
     let trust_header_value = 'https';
 
-    before( async () => {
+    beforeEach( async function() {
         let conf = server.default_conf();
         conf['preferred_password_crypt_method'] = checker_str;
 
@@ -149,5 +149,5 @@ describe( "User login", function () {
             });
     });
 
-    after(() => sinon.restore());
+    afterEach(() => sinon.restore());
 });

--- a/test/versions.ts
+++ b/test/versions.ts
@@ -5,7 +5,7 @@ import * as server from "../app";
 describe( 'Returns version list', function () {
     let app;
 
-    before( async () => {
+    beforeEach( async function() {
         process.env['TEST_RUN'] = "1";
         app = await server.createApp(this.connection, );
     });
@@ -27,7 +27,7 @@ describe( 'Returns version list', function () {
             });
     });
 
-    after( () => {
+    afterEach( async function() {
         delete process.env['TEST_RUN'];
     });
 });

--- a/test/versions.ts
+++ b/test/versions.ts
@@ -3,13 +3,15 @@ import * as server from "../app";
 
 
 describe( 'Returns version list', function () {
-    before( () => {
+    let app;
+
+    before( async () => {
         process.env['TEST_RUN'] = "1";
-        return server.start();
+        app = await server.createApp(this.connection, );
     });
 
     it( 'Gets versions', function (done) {
-        request( server.SERVER )
+        request( app )
             .get( '/api/' )
             .expect( 200 )
             .expect( 'Content-Type', /json/ )
@@ -27,6 +29,5 @@ describe( 'Returns version list', function () {
 
     after( () => {
         delete process.env['TEST_RUN'];
-        return server.stop();
     });
 });


### PR DESCRIPTION
Move the `logger`, `db` and `typeorm_connection` from globals to app singletons.  This provides better isolation and composability to match the general express/connect practices.

This will become essential trying to mock and isolate tests allowing running offline from a running database or API services.